### PR TITLE
Support running tests through watch - fix AttributeErrors

### DIFF
--- a/yanc.py
+++ b/yanc.py
@@ -94,8 +94,11 @@ class YANC(Plugin):
 
     def begin(self):
         if self.color:
-            self.conf.stream = ColorStream(self.conf.stream)
+            import sys
+            if hasattr(self.conf, "stream"):
+                self.conf.stream = ColorStream(self.conf.stream)
 
     def finalize(self, result):
         if self.color:
-            self.conf.stream = self.conf.stream._stream
+            if hasattr(self.conf, "stream") and hasattr(self.conf.stream, "_stream"):
+                self.conf.stream = self.conf.stream._stream


### PR DESCRIPTION
Hi there!

When running tests through `watch -c`  yanc currently gives `AttributeErrors`:

``` python
  AttributeError: 'Config' object has no attribute 'stream'
```

This patch fixes this by adding more `hasattr`s in `begin` and `finalyze`.

Best,

Allard
