### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,6 @@ To enable the plugin pass `--with-yanc` to `nosetests`.
     :target: https://pypi.python.org/pypi/yanc/
     :alt: Latest Version
 
-.. image:: https://pypip.in/license/yanc/badge.png
+.. image:: https://img.shields.io/pypi/l/yanc.svg
     :target: https://github.com/0compute/yanc/blob/master/LICENSE
     :alt: License


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20yanc))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `yanc`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.